### PR TITLE
fix: URL path in README.md to include `.xyz`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Collection of essential components for any modern Web3 applications. Save time a
 
 ## Documentation
 
-Visit http://buidl.turboeth/docs to view the documentation.
+Visit https://buidl.turboeth.xyz/docs to view the documentation.
 
 ## Contributing
 


### PR DESCRIPTION
- The URL to the docs was incorrectly input as `http://buidl.turboeth/docs` and is updated to  `https://buidl.turboeth.xyz/docs` to fix the hyperlink.
- The `docs` URL was using `http` - has been updated to use `https`